### PR TITLE
Update find_duplicate_guids.py

### DIFF
--- a/find_duplicate_guids.py
+++ b/find_duplicate_guids.py
@@ -86,12 +86,7 @@ def write_parsed_computers(parsed_data):
     with open('parsed_computers.json', 'w') as file:
         file.write(json.dumps(parsed_data))
 
-def get(session, url):
-    '''HTTP GET the URL and return the decoded JSON
-    '''
-    response = session.get(url)
-    response_json = response.json()
-    return response_json
+def get(session, url):     '''HTTP GET the URL and return the decoded JSON     '''     http_proxy = "http://a.b.c.d:8080"     https_proxy = "http://a.b.c.d:8080"      proxyDict = {         "http": http_proxy,         "https": https_proxy     }     response = session.get(url, proxies=proxyDict)     response_json = response.json()     return response_json
 
 def main():
     '''The main logic of the script


### PR DESCRIPTION
I have added the code i tested with proxy from a CALO hosted VM that is forced to use proxy.

When using proxy and the following code, i am faced with an error:

def get(session, url):
    '''HTTP GET the URL and return the decoded JSON
    '''
    response = session.get(url)
    response_json = response.json()
    return response_json


Process finished with exit code 0C:\Users\calo\AppData\Local\Programs\Python\Python39\python.exe C:/Users/calo/PycharmProjects/AMP/find_duplicate_guids.py
Traceback (most recent call last):
  File "C:\Users\calo\AppData\Local\Programs\Python\Python39\lib\site-packages\urllib3\connection.py", line 169, in _new_conn
    conn = connection.create_connection(
  File "C:\Users\calo\AppData\Local\Programs\Python\Python39\lib\site-packages\urllib3\util\connection.py", line 96, in create_connection
    raise err
  File "C:\Users\calo\AppData\Local\Programs\Python\Python39\lib\site-packages\urllib3\util\connection.py", line 86, in create_connection
    sock.connect(sa)
TimeoutError: [WinError 10060] A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\calo\AppData\Local\Programs\Python\Python39\lib\site-packages\urllib3\connectionpool.py", line 699, in urlopen
    httplib_response = self._make_request(
  File "C:\Users\calo\AppData\Local\Programs\Python\Python39\lib\site-packages\urllib3\connectionpool.py", line 382, in _make_request
    self._validate_conn(conn)
  File "C:\Users\calo\AppData\Local\Programs\Python\Python39\lib\site-packages\urllib3\connectionpool.py", line 1010, in _validate_conn
    conn.connect()
  File "C:\Users\calo\AppData\Local\Programs\Python\Python39\lib\site-packages\urllib3\connection.py", line 353, in connect
    conn = self._new_conn()
  File "C:\Users\calo\AppData\Local\Programs\Python\Python39\lib\site-packages\urllib3\connection.py", line 181, in _new_conn
    raise NewConnectionError(
urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPSConnection object at 0x000002430EDCBD60>: Failed to establish a new connection: [WinError 10060] A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\calo\AppData\Local\Programs\Python\Python39\lib\site-packages\requests\adapters.py", line 439, in send
    resp = conn.urlopen(
  File "C:\Users\calo\AppData\Local\Programs\Python\Python39\lib\site-packages\urllib3\connectionpool.py", line 755, in urlopen
    retries = retries.increment(
  File "C:\Users\calo\AppData\Local\Programs\Python\Python39\lib\site-packages\urllib3\util\retry.py", line 574, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='api.amp.cisco.com', port=443): Max retries exceeded with url: /v1/computers (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x000002430EDCBD60>: Failed to establish a new connection: [WinError 10060] A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond'))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\calo\PycharmProjects\AMP\find_duplicate_guids.py", line 147, in <module>
    main()
  File "C:\Users\calo\PycharmProjects\AMP\find_duplicate_guids.py", line 121, in main
    response_json = get(amp_session, computers_url)
  File "C:\Users\calo\PycharmProjects\AMP\find_duplicate_guids.py", line 92, in get
    response = session.get(url)
  File "C:\Users\calo\AppData\Local\Programs\Python\Python39\lib\site-packages\requests\sessions.py", line 555, in get
    return self.request('GET', url, **kwargs)
  File "C:\Users\calo\AppData\Local\Programs\Python\Python39\lib\site-packages\requests\sessions.py", line 542, in request
    resp = self.send(prep, **send_kwargs)
  File "C:\Users\calo\AppData\Local\Programs\Python\Python39\lib\site-packages\requests\sessions.py", line 655, in send
    r = adapter.send(request, **kwargs)
  File "C:\Users\calo\AppData\Local\Programs\Python\Python39\lib\site-packages\requests\adapters.py", line 516, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='api.amp.cisco.com', port=443): Max retries exceeded with url: /v1/computers (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x000002430EDCBD60>: Failed to establish a new connection: [WinError 10060] A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond'))

Process finished with exit code 1
 
When replacing the get function with the following code:

def get(session, url):     '''HTTP GET the URL and return the decoded JSON     '''     http_proxy = "http://a.b.c.d:8080"     https_proxy = "http://a.b.c.d:8080"      proxyDict = {         "http": http_proxy,         "https": https_proxy     }     response = session.get(url, proxies=proxyDict)     response_json = response.json()     return response_json

C:\Users\calo\AppData\Local\Programs\Python\Python39\python.exe C:/Users/calo/PycharmProjects/AMP/find_duplicate_guids.py
GUIDs found in environment: 10
Hosts with duplicate GUIDs found: 0

Process finished with exit code 0

I am replacing my lab proxy with a.b.c.d in the pull request and code just for security reasons.
You will want to replace it back with the actual configured proxy
